### PR TITLE
Error cuando ingresabas sin amigo invisible

### DIFF
--- a/secretPal-frontend/app/scripts/controllers/profile.js
+++ b/secretPal-frontend/app/scripts/controllers/profile.js
@@ -6,9 +6,9 @@ angular.module('secretPalApp')
     $scope.wishlist = [];
     $scope.giftDefault;
 
-    $scope.noFriendAlert = function () {
-      $location.path('/');
-      SweetAlert.swal("No tienes ningun amigo asignado", "avisale al administrador", "error");
+
+    $scope.haveFriend = function() {
+      return $scope.friend !== undefined;
     };
 
     $scope.wantToParticipateMsg = function () {
@@ -49,10 +49,6 @@ angular.module('secretPalApp')
         });
 
         $scope.friend = friend;
-
-        if (friend.data === "") {
-          $scope.noFriendAlert();
-        }
 
         WishlistService.getAllWishesFor($scope.friend.data, function (wishlistResponse) {
           $scope.wishlist = wishlistResponse.data;

--- a/secretPal-frontend/app/scripts/services/friendRelationService.js
+++ b/secretPal-frontend/app/scripts/services/friendRelationService.js
@@ -34,9 +34,6 @@ angular.module('secretPalApp').service('FriendRelationService', function ($http,
   this.getFriend = function (worker, callback) {
     return $http.get(buildRoute('/friend/' + worker.id)).then(function (data) {
         callback(data);
-      },
-      function () {
-        errorMsg("No se pudo conseguir su pino invisible, probablemente sea que no tiene ninguno asignado.");
       });
   };
 

--- a/secretPal-frontend/app/views/profile.html
+++ b/secretPal-frontend/app/views/profile.html
@@ -1,7 +1,11 @@
 <head class="modal-title col-lg-offset-6">
 </head>
 <div class="jumbotron">
-  <div class="container">
+  <div class="container" ng-show="!haveFriend()">
+    <h2>No tenés amigo invisible asignado aún</h2>
+    <img src="https://i.giphy.com/media/AYKv7lXcZSJig/giphy.webp" width="480" height="270" frameBorder="0" allowFullScreen>
+  </div>
+  <div class="container" ng-show="haveFriend()">
     <h2>Este año tu pino cumpleañero es:</h2>
 
     <h5>-Apoye el mouse por encima de los bloques verdes para ver la información-</h5>

--- a/secretPal-frontend/app/views/profile.html
+++ b/secretPal-frontend/app/views/profile.html
@@ -3,7 +3,7 @@
 <div class="jumbotron">
   <div class="container" ng-show="!haveFriend()">
     <h2>No tenés amigo invisible asignado aún</h2>
-    <img src="https://i.giphy.com/media/AYKv7lXcZSJig/giphy.webp" width="480" height="270" frameBorder="0" allowFullScreen>
+    <img src="https://i.giphy.com/media/AYKv7lXcZSJig/giphy.webp">
   </div>
   <div class="container" ng-show="haveFriend()">
     <h2>Este año tu pino cumpleañero es:</h2>


### PR DESCRIPTION
Aparecía un error cuando se logueaba y no tenía amigo invisible asignado. En cambio si no tenés amigo invisible cuando te logueas ahora te muestra una imagen de charlie brown triste y solo y te dice que no tenés amigo invisible asignado.