### PR TITLE
Fixea bug en envio de mails de cumpleaños de NO participantes

### DIFF
--- a/secretPal-lib/src/main/java/com/tenPines/application/ReminderSystem.java
+++ b/secretPal-lib/src/main/java/com/tenPines/application/ReminderSystem.java
@@ -37,7 +37,7 @@ public class ReminderSystem {
     }
 
     public void sendHappyBithdayMessages() {
-        workerService.getAllParticipants().stream()
+        workerService.getAllWorkers().stream()
                 .filter(worker ->
                         worker.getBirthday()
                                 .equals(

--- a/secretPal-lib/src/test/java/com/tenPines/builder/WorkerBuilder.java
+++ b/secretPal-lib/src/test/java/com/tenPines/builder/WorkerBuilder.java
@@ -48,7 +48,7 @@ public class WorkerBuilder {
         return this;
     }
 
-    public WorkerBuilder whoDoesentWantToParticipate() {
+    public WorkerBuilder whoDoesNotWantToParticipate() {
         this.wantsToParticipate = false;
         return this;
     }

--- a/secretPal-lib/src/test/java/com/tenPines/model/WorkerBuilderTest.java
+++ b/secretPal-lib/src/test/java/com/tenPines/model/WorkerBuilderTest.java
@@ -54,7 +54,7 @@ public class WorkerBuilderTest {
 
     @Test
     public void When_I_try_to_create_a_person_he_should_not_want_to_participate_yet() {
-        Worker aWorker = workerBuilder.whoDoesentWantToParticipate().build();
+        Worker aWorker = workerBuilder.whoDoesNotWantToParticipate().build();
         assertThat(aWorker.getWantsToParticipate(), is(false));
     }
 


### PR DESCRIPTION
- A la hora de chequear si hay un cumpleaños,
  solo iteraba sobre los pinos que participan.
- Se corrigieron los tests del ReminderSystem
  (Ninguno assertaba algo util), y se agregó
  un nuevo caso para el bug en si.
- Los asserts no son muy descriptivos, se dejaron
  asi por falta de tiempo.